### PR TITLE
LASB-3682 [ATS] Enable the polling to SQS to stop gracefully when ATS stops/starts

### DIFF
--- a/crime-application-tracking/src/main/resources/application.yaml
+++ b/crime-application-tracking/src/main/resources/application.yaml
@@ -117,9 +117,9 @@ cloud-platform:
       listener:
         # Graceful shutdown timeout (in milliseconds)
         shutdown:
-          timeout: 60000  # 60 seconds to allow all tasks to finish before shutdown
+          timeout: 60000 # 60 seconds to allow all tasks to finish before shutdown
         polling:
           # Timeout for the polling operation (in milliseconds)
-          timeout: 60000  # Long polling timeout for messages
+          timeout: 60000 # Long polling timeout for messages
         visibility:
-          timeout: 60  # Visibility timeout for messages in seconds
+          timeout: 60 # Visibility timeout for messages in seconds

--- a/crime-application-tracking/src/main/resources/application.yaml
+++ b/crime-application-tracking/src/main/resources/application.yaml
@@ -114,3 +114,12 @@ cloud-platform:
     sqs:
       queue:
         email_notifications: ${EMAIL_NOTIFICATIONS_QUEUE}
+      listener:
+        # Graceful shutdown timeout (in milliseconds)
+        shutdown:
+          timeout: 60000  # 60 seconds to allow all tasks to finish before shutdown
+        polling:
+          # Timeout for the polling operation (in milliseconds)
+          timeout: 60000  # Long polling timeout for messages
+        visibility:
+          timeout: 60  # Visibility timeout for messages in seconds


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3682)

Describe what you did and why.

What I did:

- Increased the graceful shutdown timeout for the SQS listener to 60 seconds (shutdown.timeout: 60000).
- Configured long polling timeout to 60 seconds (polling.timeout: 60000) to reduce empty responses and improve efficiency.
- Set the visibility timeout to 60 seconds to ensure messages remain invisible during processing.

Why I did it:

- The application was encountering a CancellationException due to the default shutdown timeout of 20 seconds, which was too short for in-flight tasks to complete.
- By increasing shutdown.timeout, the listener now waits up to 60 seconds for tasks to finish during shutdown, ensuring a clean and graceful termination.
- Adding polling.timeout improves message processing efficiency by reducing unnecessary API calls.
- Configuring visibility.timeout ensures that messages remain hidden from other consumers while they are being processed, preventing duplicate processing.

This change resolves the issue where tasks did not finish within the default shutdown period and improves the overall reliability of message processing.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
