### PR TITLE
Add IP allowlist to Application Tracking Service

### DIFF
--- a/helm_deploy/laa-crime-application-tracking-service/templates/_helpers.tpl
+++ b/helm_deploy/laa-crime-application-tracking-service/templates/_helpers.tpl
@@ -31,6 +31,16 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Create ingress configuration
+*/}}
+{{- define "laa-crime-application-tracking-service.ingress" -}}
+{{- $internalAllowlistSourceRange := (lookup "v1" "Secret" .Release.Namespace "ingress-internal-allowlist-source-range").data.INTERNAL_ALLOWLIST_SOURCE_RANGE | b64dec }}
+{{- if $internalAllowlistSourceRange }}
+  nginx.ingress.kubernetes.io/whitelist-source-range: {{ $internalAllowlistSourceRange }}
+{{- end }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "laa-crime-application-tracking-service.labels" -}}

--- a/helm_deploy/laa-crime-application-tracking-service/templates/ingress.yaml
+++ b/helm_deploy/laa-crime-application-tracking-service/templates/ingress.yaml
@@ -17,6 +17,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- include "laa-crime-application-tracking-service.ingress" . | nindent 2 }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls }}


### PR DESCRIPTION
This PR adds an IP allowlist to the Application Tracking Service for internal ingress and restricted to non-production environments.

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4147)
